### PR TITLE
Fix isolated NaNs near binary-lens boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ The `0.2` line is a redesigned release, not a patch update to `0.1.1`.
   `microjax.fspl`; the former `microjax.fastlens` package name has been
   removed.
 
+### Fixed
+
+- Reduced isolated `NaN` results near binary-lens source boundaries by making
+  the angular boundary calculation more robust.
+
 ### Compatibility
 
 - Treat `0.2.0` as potentially API-breaking relative to `0.1.1`.

--- a/src/microjax/inverse_ray/integrators/uniform.py
+++ b/src/microjax/inverse_ray/integrators/uniform.py
@@ -163,9 +163,9 @@ def mag_uniform_boundary(
             angular.status,
         )
 
-    # The bulk EA20 pass retains the conservative node-wise coefficient
+    # The bulk EA32 pass retains the conservative node-wise coefficient
     # padding.  EA40 propagates measured residuals node-wise and applies the
-    # common x64 floor once below.  The 144-point audit exposed one false EA20
+    # common x64 floor once below.  A 144-point audit exposed one false
     # acceptance when the correlated model was applied before robust root
     # convergence, so that tempting shortcut is deliberately not used.
     refinement_safety_factor = 0.01 if robust_roots and radial_strategy == "adaptive" else 1.0

--- a/src/microjax/inverse_ray_retry/extended_source.py
+++ b/src/microjax/inverse_ray_retry/extended_source.py
@@ -133,7 +133,7 @@ def mag_uniform_boundary(
     ``max_radial_subdivisions`` bounds the static radial refinement schedule.
     The default 8 is intended for scalar/direct calls.  The light-curve API
     instead selects a bounded fixed-shape schedule: its ordinary global route
-    uses an EA20, one-subdivision bulk pass and compacts only failures into an
+    uses an EA32, one-subdivision bulk pass and compacts only failures into an
     EA40, sixteen-subdivision retry.  The separately gated local-chart route
     keeps its own fixed-depth stages and a certified adaptive global fallback.
     ``robust_roots`` selects the fixed 40-step EA schedule and remains the
@@ -247,9 +247,9 @@ def mag_uniform_boundary(
             angular.status,
         )
 
-    # The bulk EA20 pass retains the conservative node-wise coefficient
+    # The bulk EA32 pass retains the conservative node-wise coefficient
     # padding.  EA40 propagates measured residuals node-wise and applies the
-    # common x64 floor once below.  The 144-point audit exposed one false EA20
+    # common x64 floor once below.  A 144-point audit exposed one false
     # acceptance when the correlated model was applied before robust root
     # convergence, so that tempting shortcut is deliberately not used.
     refinement_safety_factor = (

--- a/src/microjax/poly_solver.py
+++ b/src/microjax/poly_solver.py
@@ -44,7 +44,7 @@ __all__ = [
     "poly_roots_EA_multi",
 ]
 
-_FIXED_EA_ITERATIONS = 20
+_FIXED_EA_ITERATIONS = 32
 _ROBUST_EA_ITERATIONS = 40
 
 
@@ -201,7 +201,7 @@ def _self_inversive_root_jvp(solver, primals, tangents):
 
 @custom_jvp
 def poly_roots_EA_self_inversive_fixed(coeffs: jax.Array) -> jax.Array:
-    """Solve one polynomial with 20 fixed accelerator-friendly EA steps.
+    """Solve one polynomial with 32 fixed accelerator-friendly EA steps.
 
     This schedule is intended for large homogeneous first-pass batches. Rare
     failures remain explicit in downstream residual checks and can be compacted

--- a/tests/unittests/inverse_ray/test_boundary_angular.py
+++ b/tests/unittests/inverse_ray/test_boundary_angular.py
@@ -488,6 +488,38 @@ def test_small_source_off_unit_roots_do_not_create_false_fatal_status():
     assert float(result.error) == 0.0
 
 
+def test_fixed_binary_roots_resolve_roman_recovery_boundary_crossings():
+    # This exact GK31 radial node occurs in a Roman-model recovery case.  The
+    # former 20-step fixed EA solve found only one of the two boundary roots,
+    # so the public one-pass light curve returned NaN.
+    s = 1.025189817009389
+    q = 9.840799897016288e-6
+    rho = 0.0018453285205730348
+    w_center = 0.06940317682632598 - 0.0013061043233880167j
+    a = 0.5 * s
+    e1 = q / (1.0 + q)
+    shifted = a * (1.0 - q) / (1.0 + q)
+
+    result = angular_intervals_binary_roots(
+        1.0360819265012022,
+        0.0,
+        2.0 * jnp.pi,
+        w_center - shifted,
+        rho,
+        shifted,
+        64.0 * jnp.finfo(jnp.float64).eps,
+        a=a,
+        e1=e1,
+        robust_roots=False,
+        chart_center=0.0 + 0.0j,
+    )
+
+    assert int(result.status) == ANGULAR_OK
+    assert int(result.n_intervals) == 2
+    assert np.all(np.isfinite(np.asarray(result.intervals)))
+    assert np.all(np.diff(np.asarray(result.intervals[:2]), axis=1) > 0.0)
+
+
 @pytest.mark.slow
 def test_uniform_boundary_is_finite_at_rho_1e4_regression_point():
     result = mag_uniform_boundary(
@@ -738,7 +770,7 @@ def test_rho1e5_p0_fixtures_close_after_robust_error_retry():
     estimated_error = np.asarray(robust.estimated_error)
     tolerance = 1e-5 + 1e-4 * np.abs(reference)
 
-    # These are the original failure mechanism: the conservative EA20 pass is
+    # These are the original failure mechanism: the conservative EA32 pass is
     # rejected by radial error accounting, then the bounded EA40/8-way retry
     # closes with the correlated-roundoff estimate. This is not merely a finite
     # output assertion.


### PR DESCRIPTION
## Summary

- Increase the fixed angular root-solver iterations from 20 to 32.
- Prevent an isolated boundary-root convergence failure from producing NaN.
- Add a regression test for the failing radial quadrature node.
- Update the changelog.

## Performance

For a GPU batch containing 100 boundary-calculation points:

- 20 iterations: 76.06 ms
- 32 iterations: 81.99 ms

This is approximately a 7.8% increase for this boundary-heavy case.

## Validation

- The reported boundary-NaN case now returns a finite result.
- Relative difference from VBBinaryLensing: approximately 2.5e-7.
- Standard test suite: 166 passed, 5 skipped, 43 deselected.